### PR TITLE
 feat(theme): Configure Angular Material theme and custom palette

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "nxConsole.generateAiAgentRules": true
+}

--- a/apps/simple-swap/src/_colors.scss
+++ b/apps/simple-swap/src/_colors.scss
@@ -1,0 +1,9 @@
+// Custom Color Palette
+
+$primary-500: #6cc196;
+$primary-600: #4e8b6c;
+$base: #060606;
+$neutral-1: #0f0f0f;
+$text-high: #eeeeee;
+$text-mid: #4c4e4d;
+$error: #df5254;

--- a/apps/simple-swap/src/_theme.scss
+++ b/apps/simple-swap/src/_theme.scss
@@ -1,0 +1,77 @@
+@use '@angular/material' as mat;
+@use './colors' as *;
+
+// Include the common styles for Angular Material.
+@include mat.core();
+
+// Define the palettes for your theme using the colors you specified.
+$token-exchange-primary: mat.define-palette(
+  (
+    50: #eaf7f1,
+    100: #ccecdd,
+    200: #aaddc7,
+    300: #88ceb1,
+    400: #6cc19f,
+    500: $primary-500,
+    600: $primary-600,
+    700: #59af83,
+    800: #4fa579,
+    900: #3c9468,
+    contrast: (
+      50: #000000,
+      100: #000000,
+      200: #000000,
+      300: #000000,
+      400: #000000,
+      500: #000000,
+      600: #ffffff,
+      700: #ffffff,
+      800: #ffffff,
+      900: #ffffff,
+    ),
+  )
+);
+
+$token-exchange-accent: mat.define-palette(
+  (
+    50: $text-high,
+    100: #b4b4b4,
+    200: #818181,
+    300: $text-mid,
+    400: $neutral-1,
+    500: $base,
+    600: #050505,
+    700: #040404,
+    800: #030303,
+    900: #020202,
+    contrast: (
+      50: #000000,
+      100: #000000,
+      200: #000000,
+      300: #ffffff,
+      400: #ffffff,
+      500: #ffffff,
+      600: #ffffff,
+      700: #ffffff,
+      800: #ffffff,
+      900: #ffffff,
+    ),
+  )
+);
+
+// Define a default warn palette.
+$token-exchange-warn: mat.define-palette(mat.$red-palette);
+
+// Create the theme object.
+$token-exchange-theme: mat.define-light-theme(
+  (
+    color: (
+      primary: $token-exchange-primary,
+      accent: $token-exchange-accent,
+      warn: $token-exchange-warn,
+    ),
+  )
+);
+
+// Apply the theme to all Angular Material components.
+@include mat.all-component-themes($token-exchange-theme);

--- a/apps/simple-swap/src/styles.scss
+++ b/apps/simple-swap/src/styles.scss
@@ -1,1 +1,1 @@
-/* You can add global styles to this file, and also import other style files */
+@use "./theme" as *;

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@angular/compiler": "~20.1.0",
     "@angular/core": "~20.1.0",
     "@angular/forms": "~20.1.0",
+    "@angular/material": "^20.2.2",
     "@angular/platform-browser": "~20.1.0",
     "@angular/platform-server": "~20.1.0",
     "@angular/router": "~20.1.0",


### PR DESCRIPTION
  This commit introduces a custom theme for Angular Material components within the simple-swap application. It establishes a consistent visual
  identity by defining a specific color palette and applying it globally.

  Key changes:
   - Add @angular/material.
   - Create _colors.scss to define a central palette of named color variables.
   - Create _theme.scss to define the Angular Material theme, including primary, accent, and warn palettes using the custom colors.
   - Import the new theme into the main styles.scss file to apply it across the application.