### PR TITLE
feat(market): implement full market exchange functionality

### DIFF
--- a/apps/simple-swap/public/assets/icons/check.svg
+++ b/apps/simple-swap/public/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.1 36.0002L7.69995 24.6002L10.55 21.7502L19.1 30.3002L37.45 11.9502L40.3 14.8002L19.1 36.0002Z" fill="currentColor"/>
+</svg>

--- a/apps/simple-swap/public/mocks/tokens.json
+++ b/apps/simple-swap/public/mocks/tokens.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": 1,
+    "name": "BTC",
+    "icon": "crypto_icon",
+    "description": "Bitcoin"
+  },
+  {
+    "id": 2,
+    "name": "ETH",
+    "icon": "ethereum",
+    "description": "Ethereum"
+  },
+  {
+    "id": 3,
+    "name": "XRP",
+    "icon": "crypto_icon",
+    "description": "Ripple"
+  },
+  {
+    "id": 4,
+    "name": "LTC",
+    "icon": "crypto_icon",
+    "description": "Litecoin"
+  },
+  {
+    "id": 5,
+    "name": "ADA",
+    "icon": "crypto_icon",
+    "description": "Cardano"
+  },
+  {
+    "id": 6,
+    "name": "SOL",
+    "icon": "crypto_icon",
+    "description": "Solana"
+  },
+  {
+    "id": 7,
+    "name": "DOT",
+    "icon": "crypto_icon",
+    "description": "Polkadot"
+  },
+  {
+    "id": 8,
+    "name": "DOGE",
+    "icon": "crypto_icon",
+    "description": "Dogecoin"
+  },
+  {
+    "id": 9,
+    "name": "BNB",
+    "icon": "crypto_icon",
+    "description": "Binance Coin"
+  }
+]

--- a/apps/simple-swap/src/app/app.config.ts
+++ b/apps/simple-swap/src/app/app.config.ts
@@ -1,27 +1,28 @@
+import { provideHttpClient } from '@angular/common/http';
 import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
-  providePlatformInitializer,
   provideZonelessChangeDetection,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { appRoutes } from './app.routes';
 import {
   provideClientHydration,
   withEventReplay,
 } from '@angular/platform-browser';
-import { provideUiIcons } from 'ui';
+import { provideRouter } from '@angular/router';
+import { provideEffects } from '@ngrx/effects';
 import { provideStore } from '@ngrx/store';
+import { provideUiIcons } from 'ui';
+import { appRoutes } from './app.routes';
+import { debugReducer } from './core/store/debug.reducer';
 import { marketFeatureKey } from './features/market/store/market.actions';
 import { marketReducer } from './features/market/store/market.reducer';
-import { debugReducer } from './core/store/debug.reducer';
-import { provideEffects } from '@ngrx/effects';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideClientHydration(withEventReplay()),
     provideBrowserGlobalErrorListeners(),
     provideRouter(appRoutes),
+    provideHttpClient(),
     provideZonelessChangeDetection(),
     provideUiIcons(),
     provideStore(

--- a/apps/simple-swap/src/app/app.html
+++ b/apps/simple-swap/src/app/app.html
@@ -4,3 +4,4 @@
 <main>
   <router-outlet></router-outlet>
 </main>
+

--- a/apps/simple-swap/src/app/features/limit/container/limit.html
+++ b/apps/simple-swap/src/app/features/limit/container/limit.html
@@ -5,27 +5,16 @@
   [selectItems]="[]"
   [value]="0"
 />
-<tex-select-input
-  class="sell-input"
-  label="Sell"
-  selectLabel="Select token"
-  [selectItems]="[]"
-  [value]="0"
-/>
-<button class="swap-button"><tex-icon icon="arrow_down" /></button>
-<tex-select-input
-  label="Buy"
-  selectLabel="Select token"
-  [selectItems]="[]"
-  [value]="0"
-/>
+
+<ss-exchange-inputs [tokens]="[]" [buyAmount]="0" [sellAmount]="0" />
+
 <tex-button class="cta-button" appearance="filled" [disabled]="true"
   >Sell {{"ETH"}} for {{"BTC"}}</tex-button
 >
-<ss-exchange-rate-info
+<!-- <ss-exchange-rate-info
   class="exchange-rate-info"
   [baseCurrency]="'ETH'"
   [targetCurrency]="'BTC'"
   [rate]="0.032"
   [rateToUsd]="3762.88"
-/>
+/> -->

--- a/apps/simple-swap/src/app/features/limit/container/limit.scss
+++ b/apps/simple-swap/src/app/features/limit/container/limit.scss
@@ -10,32 +10,10 @@
   margin-bottom: 16px;
 }
 
-.sell-input {
-  display: block;
-  margin-bottom: 4px;
-}
-
 .cta-button {
   width: 100%;
   display: block;
   margin-top: 16px;
-}
-
-.swap-button {
-  cursor: pointer;
-  background: $neutral;
-  width: 52px;
-  height: 52px;
-  color: $primary-500;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 4px solid $base;
-  border-radius: 8px;
-  margin-top: -28px;
-  z-index: 2;
-  left: calc(50% - 26px);
-  position: absolute;
 }
 
 .exchange-rate-info {

--- a/apps/simple-swap/src/app/features/limit/container/limit.ts
+++ b/apps/simple-swap/src/app/features/limit/container/limit.ts
@@ -1,18 +1,13 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import {
-  TexButtonComponent,
-  TexIconComponent,
-  TexInputSelectComponent,
-} from 'ui';
-import { ExchangeRateInfo } from '../../../shared/components/exchange-rate-info/exchange-rate-info';
+import { TexButtonComponent, TexInputSelectComponent } from 'ui';
+import { ExchangeInputsComponent } from '../../../shared/components/exchange-inputs/exchange-inputs';
 
 @Component({
   selector: 'ss-limit',
   imports: [
     TexInputSelectComponent,
-    TexIconComponent,
     TexButtonComponent,
-    ExchangeRateInfo,
+    ExchangeInputsComponent,
   ],
   templateUrl: './limit.html',
   styleUrl: './limit.scss',

--- a/apps/simple-swap/src/app/features/market/container/market.html
+++ b/apps/simple-swap/src/app/features/market/container/market.html
@@ -1,24 +1,34 @@
-<tex-select-input
-  class="sell-input"
-  label="Sell"
-  selectLabel="Select token"
-  [selectItems]="[]"
-  [value]="0"
+@let tokens = tokens$ | async; @let sellAmount = sellAmount$ | async; @let
+sellToken = sellToken$ | async; @let buyToken = buyToken$ | async; @let
+buyAmount = buyAmount$ | async; @if(tokens && sellAmount !== null && buyAmount
+!== null) {
+<ss-exchange-inputs
+  [tokens]="tokens"
+  [sellAmount]="sellAmount"
+  [buyAmount]="buyAmount"
+  [sellToken]="sellToken!"
+  [buyToken]="buyToken!"
+  (sellTokenChange)="sellTokenChange($event)"
+  (buyTokenChange)="buyTokenChange($event)"
+  (sellAmountChange)="sellAmountChange($event)"
+  (swapTokensChange)="swapTokensChange()"
 />
-<button class="swap-button"><tex-icon icon="arrow_down" /></button>
-<tex-select-input
-  label="Buy"
-  selectLabel="Select token"
-  [selectItems]="[]"
-  [value]="0"
-/>
-<tex-button class="cta-button" appearance="filled" [disabled]="true"
-  >Sell {{"ETH"}} for {{"BTC"}}</tex-button
+}
+
+<tex-button
+  class="cta-button"
+  appearance="filled"
+  [disabled]="!buyAmount"
+  (clicked)="sell()"
+  >Sell {{sellToken?.name}} for {{buyToken?.name}}</tex-button
 >
+@let usdTokenRate = usdTokenRate$ | async; @let tokenRate = tokenRate$ | async;
+@if(sellToken && buyToken && usdTokenRate && tokenRate) {
 <ss-exchange-rate-info
   class="exchange-rate-info"
-  [baseCurrency]="'ETH'"
-  [targetCurrency]="'BTC'"
-  [rate]="0.032"
-  [rateToUsd]="3762.88"
+  [baseCurrency]="sellToken.name"
+  [targetCurrency]="buyToken.name"
+  [rate]="tokenRate"
+  [rateToUsd]="usdTokenRate"
 />
+}

--- a/apps/simple-swap/src/app/features/market/container/market.scss
+++ b/apps/simple-swap/src/app/features/market/container/market.scss
@@ -5,32 +5,10 @@
   margin-top: 16px;
 }
 
-.sell-input {
-  display: block;
-  margin-bottom: 4px;
-}
-
 .cta-button {
   width: 100%;
   display: block;
   margin-top: 16px;
-}
-
-.swap-button {
-  cursor: pointer;
-  background: $neutral;
-  width: 52px;
-  height: 52px;
-  color: $primary-500;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 4px solid $base;
-  border-radius: 8px;
-  margin-top: -28px;
-  z-index: 2;
-  left: calc(50% - 26px);
-  position: absolute;
 }
 
 .exchange-rate-info {

--- a/apps/simple-swap/src/app/features/market/container/market.ts
+++ b/apps/simple-swap/src/app/features/market/container/market.ts
@@ -5,23 +5,38 @@ import {
   OnInit,
 } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { MarketState } from '../store/market.state';
-import { getTokens } from '../store/market.actions';
-import { selectMarketTokens } from '../store/market.selectors';
-import {
-  TexInputSelectComponent,
-  TexButtonComponent,
-  TexIconComponent,
-} from 'ui';
+import { TexButtonComponent } from 'ui';
+import { ExchangeInputsComponent } from '../../../shared/components/exchange-inputs/exchange-inputs';
 import { ExchangeRateInfo } from '../../../shared/components/exchange-rate-info/exchange-rate-info';
+import {
+  getTokens,
+  sellTokens,
+  setBuyToken,
+  setSellAmount,
+  setSellToken,
+  swapTokens,
+} from '../store/market.actions';
+import {
+  selectBuyAmount,
+  selectBuyToken,
+  selectMarketTokens,
+  selectSellAmount,
+  selectSellToken,
+  selectTokenRate,
+  selectUsdTokenRate,
+} from '../store/market.selectors';
+import { MarketState } from '../store/market.state';
+import { AsyncPipe } from '@angular/common';
+import { Token } from '../../../shared/types/tokens.types';
 
 @Component({
   selector: 'ss-market',
   imports: [
-    TexInputSelectComponent,
     TexButtonComponent,
-    TexIconComponent,
+    ExchangeInputsComponent,
     ExchangeRateInfo,
+    ExchangeInputsComponent,
+    AsyncPipe,
   ],
   templateUrl: './market.html',
   styleUrl: './market.scss',
@@ -31,8 +46,34 @@ export default class MarketComponent implements OnInit {
   private store = inject(Store<MarketState>);
 
   protected tokens$ = this.store.select(selectMarketTokens);
+  protected sellToken$ = this.store.select(selectSellToken);
+  protected buyToken$ = this.store.select(selectBuyToken);
+  protected usdTokenRate$ = this.store.select(selectUsdTokenRate);
+  protected tokenRate$ = this.store.select(selectTokenRate);
+  protected sellAmount$ = this.store.select(selectSellAmount);
+  protected buyAmount$ = this.store.select(selectBuyAmount);
 
   ngOnInit() {
     this.store.dispatch(getTokens());
+  }
+
+  sellTokenChange(token: Token) {
+    this.store.dispatch(setSellToken({ token }));
+  }
+
+  buyTokenChange(token: Token) {
+    this.store.dispatch(setBuyToken({ token }));
+  }
+
+  sellAmountChange(amount: number) {
+    this.store.dispatch(setSellAmount({ amount }));
+  }
+
+  sell() {
+    this.store.dispatch(sellTokens());
+  }
+
+  swapTokensChange() {
+    this.store.dispatch(swapTokens());
   }
 }

--- a/apps/simple-swap/src/app/features/market/store/market.actions.ts
+++ b/apps/simple-swap/src/app/features/market/store/market.actions.ts
@@ -1,5 +1,6 @@
 import { createAction, props } from '@ngrx/store';
 import { Token } from '../../../shared/types/tokens.types';
+import { create } from 'domain';
 
 export const marketFeatureKey = 'Market';
 
@@ -12,3 +13,37 @@ export const getTokensFailed = createAction(
   `[${marketFeatureKey}] Get tokens failed`,
   props<{ error: Error }>()
 );
+
+export const setSellToken = createAction(
+  `[${marketFeatureKey}] Set sell token`,
+  props<{ token: Token }>()
+);
+
+export const setBuyToken = createAction(
+  `[${marketFeatureKey}] Set buy token`,
+  props<{ token: Token }>()
+);
+
+export const setTokenRate = createAction(
+  `[${marketFeatureKey}] Set token rate`,
+  props<{ rate: number }>()
+);
+
+export const setUsdTokenRate = createAction(
+  `[${marketFeatureKey}] Set usd token rate`,
+  props<{ rate: number }>()
+);
+
+export const setSellAmount = createAction(
+  `[${marketFeatureKey}] Set sell amount`,
+  props<{ amount: number }>()
+);
+
+export const setBuyAmount = createAction(
+  `[${marketFeatureKey}] Set buy amount`,
+  props<{ amount: number }>()
+);
+
+export const sellTokens = createAction(`[${marketFeatureKey}] Sell tokens`);
+
+export const swapTokens = createAction(`[${marketFeatureKey}] Swap tokens`);

--- a/apps/simple-swap/src/app/features/market/store/market.effects.ts
+++ b/apps/simple-swap/src/app/features/market/store/market.effects.ts
@@ -1,23 +1,121 @@
 import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { getTokens, getTokensFailed, getTokensSuccess } from './market.actions';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { Store } from '@ngrx/store';
+import {
+  catchError,
+  filter,
+  map,
+  mergeMap,
+  of,
+  switchMap,
+  tap,
+  withLatestFrom,
+} from 'rxjs';
+import { CurrencyExchangeService } from '../../../shared/services/currency-exchange/currency-exchange-service';
+import { TokensService } from '../../../shared/services/tokens/tokens.service';
+import {
+  getTokens,
+  getTokensFailed,
+  getTokensSuccess,
+  sellTokens,
+  setBuyAmount,
+  setBuyToken,
+  setSellAmount,
+  setSellToken,
+  setTokenRate,
+  setUsdTokenRate,
+} from './market.actions';
+import {
+  selectBuyToken,
+  selectMarket,
+  selectSellAmount,
+  selectSellToken,
+  selectTokenRate,
+} from './market.selectors';
+import { MatDialog } from '@angular/material/dialog';
+import { TransactionFinishedDialog } from '../../../shared/components/transactin-finished-dialog/transaction-finished-dialog';
+import { TransactionFinishedDialogData } from '../../../shared/types/transaction-finished-dialog.types';
 
 @Injectable()
 export class MarketEffects {
   private actions$ = inject(Actions);
+  private tokensService = inject(TokensService);
+  private exchangeService = inject(CurrencyExchangeService);
+  private store = inject(Store);
+  private dialog = inject(MatDialog);
 
   getTokens$ = createEffect(() =>
     this.actions$.pipe(
       ofType(getTokens),
       switchMap(() =>
-        of([]).pipe(
+        this.tokensService.fetchTokens().pipe(
           map((tokens) => getTokensSuccess({ tokens })),
           catchError(() =>
             of(getTokensFailed({ error: new Error('Get tokens error') }))
           )
         )
       )
+    )
+  );
+
+  setTokenRate$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(setSellToken, setBuyToken),
+      withLatestFrom(
+        this.store.select(selectSellToken),
+        this.store.select(selectBuyToken)
+      ),
+      filter(([, sellToken, buyToken]) => !!sellToken && !!buyToken),
+      switchMap(([, sellToken, buyToken]) =>
+        this.exchangeService
+          .getTokenRate(sellToken!.id, buyToken!.id)
+          .pipe(map((rate) => setTokenRate({ rate })))
+      )
+    )
+  );
+
+  setUsdTokenRate$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(setSellToken),
+      switchMap(({ token }) =>
+        this.exchangeService
+          .getUsdTokenRate(token.id)
+          .pipe(map((rate) => setUsdTokenRate({ rate })))
+      )
+    )
+  );
+
+  setByAmount$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(setSellAmount, setTokenRate),
+      withLatestFrom(
+        this.store.select(selectSellAmount),
+        this.store.select(selectTokenRate)
+      ),
+      filter(([, , rate]) => !!rate),
+      map(([, amount, rate]) =>
+        this.exchangeService.exchangeCurrency(amount, rate || 1)
+      ),
+      map((buyAmount) => setBuyAmount({ amount: buyAmount }))
+    )
+  );
+
+  sellTokens$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(sellTokens),
+      withLatestFrom(this.store.select(selectMarket)),
+      tap(([, { buyAmount, sellAmount, buyToken, sellToken, usdTokenRate }]) =>
+        this.dialog.open(TransactionFinishedDialog, {
+          data: {
+            buyAmount,
+            sellAmount,
+            buyToken: buyToken?.name || '',
+            sellToken: sellToken?.name || '',
+            usdRate: usdTokenRate || 1,
+          } satisfies TransactionFinishedDialogData,
+        })
+      ),
+      map(() => setSellAmount({ amount: 0 }))
     )
   );
 }

--- a/apps/simple-swap/src/app/features/market/store/market.reducer.ts
+++ b/apps/simple-swap/src/app/features/market/store/market.reducer.ts
@@ -1,10 +1,40 @@
 import { createReducer, on } from '@ngrx/store';
-import { getTokens, getTokensFailed, getTokensSuccess } from './market.actions';
+import {
+  getTokens,
+  getTokensFailed,
+  getTokensSuccess,
+  setBuyAmount,
+  setBuyToken,
+  setSellAmount,
+  setSellToken,
+  setTokenRate,
+  setUsdTokenRate,
+  swapTokens,
+} from './market.actions';
 import { marketInitialState } from './market.state';
 
 export const marketReducer = createReducer(
   marketInitialState,
   on(getTokens, (state) => ({ ...state, tokens: [] })),
   on(getTokensSuccess, (state, { tokens }) => ({ ...state, tokens })),
-  on(getTokensFailed, (state) => ({ ...state, tokens: [] }))
+  on(getTokensFailed, (state) => ({ ...state, tokens: [] })),
+  on(setSellToken, (state, { token }) => ({ ...state, sellToken: token })),
+  on(setBuyToken, (state, { token }) => ({ ...state, buyToken: token })),
+  on(setTokenRate, (state, { rate }) => ({
+    ...state,
+    tokenRate: rate,
+  })),
+  on(setUsdTokenRate, (state, { rate }) => ({
+    ...state,
+    usdTokenRate: rate,
+  })),
+  on(setSellAmount, (state, { amount }) => ({ ...state, sellAmount: amount })),
+  on(setBuyAmount, (state, { amount }) => ({ ...state, buyAmount: amount })),
+  on(swapTokens, (state) => ({
+    ...state,
+    sellToken: state.buyToken,
+    buyToken: state.sellToken,
+    sellAmount: state.buyAmount,
+    buyAmount: state.sellAmount,
+  }))
 );

--- a/apps/simple-swap/src/app/features/market/store/market.selectors.ts
+++ b/apps/simple-swap/src/app/features/market/store/market.selectors.ts
@@ -9,3 +9,33 @@ export const selectMarketTokens = createSelector(
   selectMarket,
   (state: MarketState) => state.tokens
 );
+
+export const selectSellToken = createSelector(
+  selectMarket,
+  (state: MarketState) => state.sellToken
+);
+
+export const selectBuyToken = createSelector(
+  selectMarket,
+  (state: MarketState) => state.buyToken
+);
+
+export const selectTokenRate = createSelector(
+  selectMarket,
+  (state: MarketState) => state.tokenRate
+);
+
+export const selectUsdTokenRate = createSelector(
+  selectMarket,
+  (state: MarketState) => state.usdTokenRate
+);
+
+export const selectSellAmount = createSelector(
+  selectMarket,
+  (state: MarketState) => state.sellAmount
+);
+
+export const selectBuyAmount = createSelector(
+  selectMarket,
+  (state: MarketState) => state.buyAmount
+);

--- a/apps/simple-swap/src/app/features/market/store/market.state.ts
+++ b/apps/simple-swap/src/app/features/market/store/market.state.ts
@@ -2,8 +2,16 @@ import { Token } from '../../../shared/types/tokens.types';
 
 export type MarketState = {
   tokens: Token[];
+  sellToken?: Token;
+  buyToken?: Token;
+  tokenRate?: number;
+  usdTokenRate?: number;
+  sellAmount: number;
+  buyAmount: number;
 };
 
 export const marketInitialState: MarketState = {
   tokens: [],
+  sellAmount: 0,
+  buyAmount: 0,
 };

--- a/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.html
+++ b/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.html
@@ -1,0 +1,22 @@
+<tex-select-input
+  class="sell-input"
+  label="Sell"
+  selectLabel="Select token"
+  [selectItems]="tokens()"
+  [value]="sellAmount()"
+  [selectedValue]="sellToken()"
+  (valueChange)="setSellAmount($event)"
+  (selectedValueChange)="setSelectedSellToken($event)"
+/>
+<button class="swap-button">
+  <tex-icon icon="arrow_down" (click)="swapTokens()" />
+</button>
+<tex-select-input
+  label="Buy"
+  selectLabel="Select token"
+  [disabled]="true"
+  [selectItems]="tokens()"
+  [value]="buyAmount()"
+  [selectedValue]="buyToken()"
+  (selectedValueChange)="setSelectedBuyToken($event)"
+/>

--- a/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.scss
+++ b/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.scss
@@ -1,0 +1,26 @@
+@use 'libs/ui/src/theme/colors.scss' as *;
+
+:host {
+}
+
+.sell-input {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.swap-button {
+  cursor: pointer;
+  background: $neutral;
+  width: 52px;
+  height: 52px;
+  color: $primary-500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 4px solid $base;
+  border-radius: 8px;
+  margin-top: -28px;
+  z-index: 2;
+  left: calc(50% - 26px);
+  position: absolute;
+}

--- a/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.spec.ts
+++ b/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ExchangeInputsComponent } from './exchange-inputs';
+import { inputBinding } from '@angular/core';
+
+describe('ExchangeInputsComponent', () => {
+  let component: ExchangeInputsComponent;
+  let fixture: ComponentFixture<ExchangeInputsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExchangeInputsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExchangeInputsComponent, {
+      bindings: [
+        inputBinding('tokens', () => []),
+        inputBinding('sellAmount', () => 1),
+        inputBinding('buyAmount', () => 2),
+      ],
+    });
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.ts
+++ b/apps/simple-swap/src/app/shared/components/exchange-inputs/exchange-inputs.ts
@@ -1,0 +1,44 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+import { SelectItem, TexIconComponent, TexInputSelectComponent } from 'ui';
+import { Token } from '../../types/tokens.types';
+
+@Component({
+  selector: 'ss-exchange-inputs',
+  imports: [TexInputSelectComponent, TexIconComponent],
+  templateUrl: './exchange-inputs.html',
+  styleUrl: './exchange-inputs.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExchangeInputsComponent {
+  tokens = input.required<Token[]>();
+  sellAmount = input.required<number>();
+  buyAmount = input.required<number>();
+  sellToken = input<Token>();
+  buyToken = input<Token>();
+
+  sellTokenChange = output<Token>();
+  buyTokenChange = output<Token>();
+  sellAmountChange = output<number>();
+  swapTokensChange = output<void>();
+
+  setSelectedBuyToken(token: SelectItem | undefined) {
+    this.buyTokenChange.emit(token as Token);
+  }
+  setSelectedSellToken(token: SelectItem | undefined) {
+    this.sellTokenChange.emit(token as Token);
+  }
+  setSellAmount(amount: number | undefined) {
+    if (typeof amount === 'number') {
+      this.sellAmountChange.emit(amount);
+    }
+  }
+
+  swapTokens() {
+    this.swapTokensChange.emit();
+  }
+}

--- a/apps/simple-swap/src/app/shared/components/exchange-rate-info/exchange-rate-info.html
+++ b/apps/simple-swap/src/app/shared/components/exchange-rate-info/exchange-rate-info.html
@@ -1,4 +1,5 @@
 <p>
-  1 {{baseCurrency()}} = {{targetValue()}} {{targetCurrency()}}
+  1 {{baseCurrency()}} = {{targetValue() | number : '1.0-3' }}
+  {{targetCurrency()}}
   <span class="usd-rate">({{usdValue() | currency: "USD" }})</span>
 </p>

--- a/apps/simple-swap/src/app/shared/components/exchange-rate-info/exchange-rate-info.ts
+++ b/apps/simple-swap/src/app/shared/components/exchange-rate-info/exchange-rate-info.ts
@@ -1,4 +1,4 @@
-import { CurrencyPipe } from '@angular/common';
+import { CurrencyPipe, DecimalPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -10,7 +10,7 @@ import { CurrencyExchangeService } from '../../services/currency-exchange/curren
 
 @Component({
   selector: 'ss-exchange-rate-info',
-  imports: [CurrencyPipe],
+  imports: [CurrencyPipe, DecimalPipe],
   templateUrl: './exchange-rate-info.html',
   styleUrl: './exchange-rate-info.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.html
+++ b/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.html
@@ -1,0 +1,28 @@
+<tex-dialog>
+  <div class="header">
+    <tex-icon icon="check" />
+    <h2 class="header__text">Transaction finished!</h2>
+  </div>
+
+  <div class="transaction-details">
+    <p>Transaction info:</p>
+    <p>
+      <span>Buy</span
+      ><span>{{data.buyAmount | number : '1.0-3'}} {{data.buyToken}}</span>
+    </p>
+    <p>
+      <span>Sell</span
+      ><span>{{data.sellAmount | number : '1.0-3'}} {{data.sellToken}}</span>
+    </p>
+    <p>
+      <span>Price</span
+      ><span
+        >1 {{data.sellToken}} = {{data.buyAmount | number : '1.0-3'}}
+        {{data.buyToken}} ({{data.usdRate | number : '1.0-3'}})</span
+      >
+    </p>
+  </div>
+  <tex-button class="close-button" appearance="filled" (clicked)="closeDialog()"
+    >Close</tex-button
+  >
+</tex-dialog>

--- a/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.scss
+++ b/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.scss
@@ -1,0 +1,36 @@
+@use 'libs/ui/src/theme/colors.scss' as *;
+
+:host {
+  min-width: 480px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  tex-icon {
+    color: $primary-500;
+    transform: scale(2);
+    margin-bottom: 6px;
+  }
+
+  &__text {
+    font-size: 24px;
+    font-weight: 600;
+  }
+}
+
+.transaction-details {
+  p {
+    span {
+      display: inline-block;
+      width: 50%;
+    }
+  }
+}
+
+.close-button {
+  margin-top: 10px;
+  width: 100%;
+}

--- a/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.spec.ts
+++ b/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.spec.ts
@@ -1,0 +1,5 @@
+describe('TransactionFinishedDialog', () => {
+  it('should create', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.ts
+++ b/apps/simple-swap/src/app/shared/components/transactin-finished-dialog/transaction-finished-dialog.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { TexDialogComponent, TexIconComponent, TexButtonComponent } from 'ui';
+import { TransactionFinishedDialogData } from '../../types/transaction-finished-dialog.types';
+import { DecimalPipe } from '@angular/common';
+
+@Component({
+  selector: 'ss-transaction-finished-dialog',
+  imports: [
+    TexDialogComponent,
+    TexIconComponent,
+    TexButtonComponent,
+    DecimalPipe,
+  ],
+  templateUrl: './transaction-finished-dialog.html',
+  styleUrl: './transaction-finished-dialog.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TransactionFinishedDialog {
+  data: TransactionFinishedDialogData = inject(MAT_DIALOG_DATA);
+  dialog = inject(MatDialog);
+
+  closeDialog() {
+    console.log('close');
+    this.dialog.closeAll();
+  }
+}

--- a/apps/simple-swap/src/app/shared/services/currency-exchange/currency-exchange-service.ts
+++ b/apps/simple-swap/src/app/shared/services/currency-exchange/currency-exchange-service.ts
@@ -1,10 +1,31 @@
 import { Injectable } from '@angular/core';
+import { interval, map, Observable } from 'rxjs';
+
+const MIN_RANGE = 3770;
+const MAX_RANGE = 3790;
+const RANGE_DIFF = MAX_RANGE - MIN_RANGE;
+const INTERVAL = 1000;
 
 @Injectable({
   providedIn: 'root',
 })
 export class CurrencyExchangeService {
-  exchangeCurrency(amount: number, rate: number) {
+  exchangeCurrency(amount: number, rate: number): number {
     return amount * rate;
+  }
+
+  getTokenRate(sellTokenId: number, buyTokenId: number): Observable<number> {
+    return interval(INTERVAL).pipe(
+      map(() => Math.round(Math.random() * 100) / 100)
+    );
+  }
+
+  getUsdTokenRate(tokenId: number): Observable<number> {
+    return interval(INTERVAL).pipe(
+      map(() => {
+        const base = Math.random() * RANGE_DIFF;
+        return MIN_RANGE + base;
+      })
+    );
   }
 }

--- a/apps/simple-swap/src/app/shared/services/tokens/tokens.service.spec.ts
+++ b/apps/simple-swap/src/app/shared/services/tokens/tokens.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TokensService } from './tokens.service';
+import { provideHttpClient } from '@angular/common/http';
+
+describe('TokensService', () => {
+  let service: TokensService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(TokensService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/simple-swap/src/app/shared/services/tokens/tokens.service.ts
+++ b/apps/simple-swap/src/app/shared/services/tokens/tokens.service.ts
@@ -1,0 +1,15 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Token } from '../../types/tokens.types';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TokensService {
+  private http = inject(HttpClient);
+
+  fetchTokens(): Observable<Token[]> {
+    return this.http.get<Token[]>('mocks/tokens.json');
+  }
+}

--- a/apps/simple-swap/src/app/shared/types/transaction-finished-dialog.types.ts
+++ b/apps/simple-swap/src/app/shared/types/transaction-finished-dialog.types.ts
@@ -1,0 +1,7 @@
+export type TransactionFinishedDialogData = {
+  buyAmount: number;
+  sellAmount: number;
+  buyToken: string;
+  sellToken: string;
+  usdRate: number;
+};

--- a/libs/ui/src/assets/icons/check.svg
+++ b/libs/ui/src/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.1 36.0002L7.69995 24.6002L10.55 21.7502L19.1 30.3002L37.45 11.9502L40.3 14.8002L19.1 36.0002Z" fill="currentColor"/>
+</svg>

--- a/libs/ui/src/components/tex-dialog/tex-dialog.component.html
+++ b/libs/ui/src/components/tex-dialog/tex-dialog.component.html
@@ -1,0 +1,3 @@
+<mat-dialog-content>
+  <ng-content></ng-content>
+</mat-dialog-content>

--- a/libs/ui/src/components/tex-dialog/tex-dialog.component.scss
+++ b/libs/ui/src/components/tex-dialog/tex-dialog.component.scss
@@ -1,0 +1,11 @@
+@use '@angular/material' as mat;
+@use '../../theme/colors.scss' as *;
+
+:host {
+  min-width: 480px;
+  @include mat.dialog-overrides(
+    (
+      container-color: $neutral,
+    )
+  );
+}

--- a/libs/ui/src/components/tex-dialog/tex-dialog.component.spec.ts
+++ b/libs/ui/src/components/tex-dialog/tex-dialog.component.spec.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TexDialogComponent } from './tex-dialog.component';
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, TexDialogComponent],
+  template: ` <tex-dialog>Dialog</tex-dialog> `,
+})
+class TestHostComponent {}
+
+describe('TexDialogComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    const select = fixture.debugElement.query(By.directive(TexDialogComponent));
+    expect(select).toBeTruthy();
+  });
+});

--- a/libs/ui/src/components/tex-dialog/tex-dialog.component.stories.ts
+++ b/libs/ui/src/components/tex-dialog/tex-dialog.component.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig, moduleMetadata } from '@storybook/angular';
+import { TexDialogComponent } from './tex-dialog.component';
+import { provideUiIcons } from '../../services/icon-registry-service/icon-registry-service';
+import { TexButtonComponent } from '../tex-button/tex-button.component';
+
+const meta: Meta<TexDialogComponent> = {
+  component: TexDialogComponent,
+  title: 'TexDialogComponent',
+  decorators: [
+    moduleMetadata({
+      imports: [TexButtonComponent],
+    }),
+    applicationConfig({
+      providers: [provideUiIcons()],
+    }),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<TexDialogComponent>;
+
+export const Dialog: Story = {
+  render: () => ({
+    template: `<tex-dialog>Dialog</tex-dialog>`,
+  }),
+};

--- a/libs/ui/src/components/tex-dialog/tex-dialog.component.ts
+++ b/libs/ui/src/components/tex-dialog/tex-dialog.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatDialogModule } from '@angular/material/dialog';
+
+@Component({
+  selector: 'tex-dialog',
+  imports: [MatDialogModule],
+  templateUrl: './tex-dialog.component.html',
+  styleUrl: './tex-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TexDialogComponent {}

--- a/libs/ui/src/components/tex-input-select/tex-input-select.component.html
+++ b/libs/ui/src/components/tex-input-select/tex-input-select.component.html
@@ -3,11 +3,12 @@
   <div class="input-wrapper">
     <input
       matInput
+      [disabled]="disabled()"
       [placeholder]="placeholder()"
       [type]="type()"
       [readonly]="readonly()"
       [ngModel]="value()"
-      (ngModelChange)="setSelectValue($event)"
+      (ngModelChange)="setValue($event)"
     />
     @if(readonlySelect()) {
     <div class="select-readonly">

--- a/libs/ui/src/components/tex-input-select/tex-input-select.component.scss
+++ b/libs/ui/src/components/tex-input-select/tex-input-select.component.scss
@@ -6,8 +6,11 @@
     (
       hover-state-layer-opacity: 0,
       filled-container-color: $neutral,
+      filled-disabled-container-color: $neutral,
       filled-input-text-color: $text-high,
+      filled-disabled-label-text-color: $text-high,
       filled-focus-label-text-color: $text-high,
+      filled-disabled-input-text-color: $text-high,
       filled-label-text-color: $text-high,
       filled-caret-color: $text-high,
       filled-label-text-size: 18px,
@@ -40,6 +43,9 @@ input[type='number'] {
         border: 1px solid $primary-500;
       }
     }
+  }
+  ::ng-deep.mat-mdc-text-field-wrapper {
+    border: 1px solid $base;
   }
 }
 

--- a/libs/ui/src/components/tex-input-select/tex-input-select.component.ts
+++ b/libs/ui/src/components/tex-input-select/tex-input-select.component.ts
@@ -26,18 +26,21 @@ import { TexIconComponent } from '../tex-icon/tex-icon.component';
 })
 export class TexInputSelectComponent {
   label = input.required<string>();
+  disabled = input<boolean>(false);
   type = input<string>('number');
   readonly = input<boolean>(false);
   placeholder = input<string>('');
   value = model<number>();
 
   selectLabel = input<string>('Select value');
-  selectedValue = model<SelectItem | undefined>();
+  selectedValue = model<SelectItem>();
   selectItems = input.required<SelectItem[]>();
   readonlySelect = input<boolean>(false);
 
-  setValue(newValue: number) {
-    this.value.set(newValue);
+  setValue(newValue: string) {
+    const value = parseInt(newValue);
+
+    this.value.set(!isNaN(value) ? value : 0);
   }
 
   setSelectValue(item: SelectItem | undefined) {

--- a/libs/ui/src/components/tex-select/tex-select.component.ts
+++ b/libs/ui/src/components/tex-select/tex-select.component.ts
@@ -22,7 +22,7 @@ import { SelectItem } from '../../types/select.types';
 export class TexSelectComponent {
   selectLabel = input.required<string>();
   selectItems = input.required<SelectItem[]>();
-  selectedValue = model<SelectItem | undefined>();
+  selectedValue = model<SelectItem>();
 
   appearance = computed<ButtonAppearance>(() =>
     this.selectedValue() ? 'outlined' : 'filled'

--- a/libs/ui/src/constants/icons.constants.ts
+++ b/libs/ui/src/constants/icons.constants.ts
@@ -5,4 +5,5 @@ export const IconsList = [
   'search',
   'arrow_down',
   'ethereum',
+  'check',
 ] as const;

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -3,5 +3,7 @@ export * from './components/tex-icon/tex-icon.component';
 export * from './components/tex-chips/tex-chips.component';
 export * from './components/tex-chip/tex-chip.component';
 export * from './components/tex-input-select/tex-input-select.component';
+export * from './components/tex-dialog/tex-dialog.component';
 export * from './services/icon-registry-service/icon-registry-service';
 export * from './types/icons.types';
+export * from './types/select.types';

--- a/libs/ui/src/theme/theme.scss
+++ b/libs/ui/src/theme/theme.scss
@@ -1,5 +1,6 @@
 @use '@angular/material' as mat;
 @use './palettes.scss' as *;
+@use './colors.scss' as *;
 
 // Include the common styles for Angular Material.
 @include mat.core();
@@ -43,6 +44,10 @@ mat-form-field {
   .mat-mdc-form-field-subscript-wrapper {
     height: 0;
   }
+
+  .mdc-text-field--disabled {
+    pointer-events: all;
+  }
 }
 
 .cdk-overlay-pane {
@@ -56,4 +61,13 @@ button {
   background: none;
   outline: none;
   border: none;
+}
+
+mat-dialog-container {
+  mat-dialog-content.mat-mdc-dialog-content {
+    background: $neutral;
+  }
+  .mdc-dialog__surface {
+    border-radius: 16px;
+  }
 }


### PR DESCRIPTION
Connects the market page UI to a fully implemented NgRx store to manage the entire token swap process.

- Introduces a 'TokensService' to fetch token data from a mock JSON file and enhances 'CurrencyExchangeService' to provide simulated real-time rates.

- Refactors the UI by creating a reusable 'exchange-inputs' component, simplifying the market and limit page templates.

- Adds a 'transaction-finished-dialog' that displays a summary of the swap upon completion.

- The state now handles selecting tokens, calculating buy/sell amounts based on live rates, and swapping the selected tokens.